### PR TITLE
Ensure components directory exists and clean node_modules

### DIFF
--- a/src/SveltePreset.php
+++ b/src/SveltePreset.php
@@ -10,9 +10,11 @@ class SveltePreset extends Preset
 {
     public static function install()
     {
+        static::ensureComponentDirectoryExists();
         static::updatePackages();
         static::updateMix();
         static::updateScripts();
+        static::removeNodeModules();
     }
 
     public static function updatePackageArray($packages)


### PR DESCRIPTION
Thanks for the preset - saved me some time getting started with Svelte in Laravel. I noticed that both the React and Vue core presets first check that the component directory exists and finally remove the current `node_modules` directory so I've added those in to `install()` here.

While most people will probably run the preset from a fresh Laravel install I think it would be good to have the check as without it `updateScripts()` throws an exception if the directory is not there. Run `php artisan preset none` then `php artisan preset svelte`